### PR TITLE
Fix theme dropdown clipping

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,11 +57,15 @@ function App() {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="m-4 sm:grid sm:grid-cols-[1fr_auto_1fr] max-sm:flex max-sm:justify-between max-sm: gap-2 items-center">
+      <div
+        className={`m-4 gap-2 items-center sm:grid sm:grid-cols-[1fr_auto_1fr] 
+          max-sm:flex max-sm:justify-between`}
+      >
         <h1 className="col-start-2">Armand Bernard&apos;s Web CV</h1>
         <div className="justify-self-end flex grid-col items-baseline gap-2 relative">
           <label
-            className="max-sm:text-xs max-sm:absolute max-sm:px-1 max-sm:left-1 max-sm:top-[-0.5rem] max-sm:bg-background"
+            className={`max-sm:text-xs max-sm:absolute max-sm:px-1 max-sm:left-1 
+              max-sm:top-[-0.5rem] max-sm:bg-background`}
             id={themePickerLabel}
           >
             Theme

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,21 +56,28 @@ function App() {
   }, [setTheme, systemPreferredTheme, themePreference]);
 
   return (
-    <div>
-      <div className="absolute right-4 top-4 flex items-baseline gap-2">
-        <label id={themePickerLabel}>Theme</label>
-        <Select
-          aria-labelledby={themePickerLabel}
-          className="w-20"
-          options={["auto", "dark", "light"]}
-          selectedOption={themePreference ?? "auto"}
-          setSelectedOption={setThemePreference}
-        />
+    <div className="flex flex-col gap-4">
+      <div className="m-4 sm:grid sm:grid-cols-[1fr_auto_1fr] max-sm:flex max-sm:justify-between max-sm: gap-2 items-center">
+        <h1 className="col-start-2">Armand Bernard&apos;s Web CV</h1>
+        <div className="justify-self-end flex grid-col items-baseline gap-2 relative">
+          <label
+            className="max-sm:text-xs max-sm:absolute max-sm:px-1 max-sm:left-1 max-sm:top-[-0.5rem] max-sm:bg-background"
+            id={themePickerLabel}
+          >
+            Theme
+          </label>
+          <Select
+            aria-labelledby={themePickerLabel}
+            className="sm:w-20"
+            options={["auto", "dark", "light"]}
+            selectedOption={themePreference ?? "auto"}
+            setSelectedOption={setThemePreference}
+          />
+        </div>
       </div>
 
       <div className="flex justify-center">
         <main className="max-w-4xl flex flex-col px-4 flex-grow gap-4 mb-8">
-          <h1 className="self-center m-4">Armand Bernard&apos;s Web CV</h1>
           <AboutMe />
           <Experience />
           <Education />

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -123,7 +123,8 @@ export const Select: FunctionComponent<SelectProps> = (props) => {
         aria-expanded={open}
         role="combobox"
         ref={buttonRef}
-        className="p-2 border border-neutral-400 dark:border-white rounded text-left flex justify-between gap-2"
+        className={`p-2 border items-center border-neutral-400 dark:border-white rounded 
+          text-left flex justify-between gap-2`}
         onClick={onClickExpand}
         value={props.selectedOption}
       >
@@ -135,7 +136,8 @@ export const Select: FunctionComponent<SelectProps> = (props) => {
           id={listBoxId}
           aria-label={props["aria-label"]}
           aria-labelledby={props["aria-labelledby"]}
-          className="flex flex-col absolute border border-neutral-400 dark:border-white rounded w-full"
+          className={`flex flex-col absolute border bg-background border-neutral-400 dark:border-white 
+            rounded w-full`}
           role="listbox"
           onBlur={onBlur}
           onKeyDown={onMenuKeyDown}

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -136,8 +136,8 @@ export const Select: FunctionComponent<SelectProps> = (props) => {
           id={listBoxId}
           aria-label={props["aria-label"]}
           aria-labelledby={props["aria-labelledby"]}
-          className={`flex flex-col absolute border bg-background border-neutral-400 dark:border-white 
-            rounded w-full`}
+          className={`flex flex-col absolute border bg-background border-neutral-400 
+          dark:border-white rounded w-full`}
           role="listbox"
           onBlur={onBlur}
           onKeyDown={onMenuKeyDown}

--- a/src/index.css
+++ b/src/index.css
@@ -22,17 +22,19 @@
   }
 
   body {
-    @apply bg-white text-black dark:bg-neutral-800 dark:text-white;
+    @apply bg-background  text-black  dark:text-white;
     @apply max-sm:text-sm;
   }
 
   html:not(.dark) {
+    --background: white;
     --primary: #0ea5e9; /* sky-500 */
     --tag-background: #bae6fd; /* sky-200 */
     --grade: #d4d4d4; /* neutral-300 */
   }
 
   html.dark {
+    --background: #262626;
     --primary: #38bdf8; /* sky-400 */
     --tag-background: #0369a1; /* sky-700 */
     --grade: #525252; /* neutral-600 */

--- a/src/index.css
+++ b/src/index.css
@@ -22,7 +22,7 @@
   }
 
   body {
-    @apply bg-background  text-black  dark:text-white;
+    @apply bg-background text-black dark:text-white;
     @apply max-sm:text-sm;
   }
 

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -9,6 +9,7 @@ module.exports = {
     },
     extend: {
       colors: {
+        background: "var(--background)",
         primary: "var(--primary)",
         "tag-background": "var(--tag-background)",
         grade: "var(--grade)",


### PR DESCRIPTION
On mobile, the theme picker clips with the main header.

![image](https://user-images.githubusercontent.com/25556936/218839701-42613c38-4f1e-40f2-8425-3866a236c0e6.png)

This fixes that by not using absolute positioning and shrinking the footprint of the toggle on small screens.

![image](https://user-images.githubusercontent.com/25556936/218839681-45a40945-ee74-407b-b256-9e7277387036.png)
