### PR TITLE
Improve dropdown for mobile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,7 +67,7 @@ function App() {
 
   return (
     <ThemeContext.Provider value={activeTheme}>
-      <div className="flex items-center gap-2 fixed sm:top-0 right-0 max-sm:bottom-0 print:invisible p-4">
+      <div className="flex items-center gap-4 fixed sm:top-0 right-0 max-sm:bottom-0 print:invisible p-4">
         <div className="flex items-baseline gap-2 relative">
           <label
             className={`max-sm:text-sm max-sm:absolute py-1 px-2 max-sm:left-2 rounded
@@ -103,7 +103,7 @@ function App() {
           </button>
         )}
       </div>
-      <div className="space-y-4">
+      <div className="space-y-4 max-sm:mb-16">
         <div className="flex justify-center">
           <main className="max-w-4xl px-4 flex-grow space-y-4 mb-8">
             <h1 className="text-center mt-6">Armand Bernard&apos;s Web CV</h1>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,7 +87,7 @@ function App() {
         </div>
         {!isAndroid && (
           <button
-            className="material-symbols-outlined text-4xl bg-background rounded-full"
+            className="material-symbols-outlined text-4xl bg-background rounded-full max-sm:p-2"
             onClick={() => window.print()}
           >
             print

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,6 +78,7 @@ function App() {
           </label>
           {windowWidth < 640 ? (
             <SelectMobile
+              className="shadow-lg"
               aria-labelledby={themePickerLabel}
               options={["auto", "dark", "light"]}
               selectedOption={themePreference ?? "auto"}
@@ -96,7 +97,7 @@ function App() {
         {!isAndroid && (
           <button
             className={`material-symbols-outlined text-4xl bg-background rounded-full max-sm:p-2 
-              border border-neutral-400 dark:border-white`}
+              border border-neutral-400 dark:border-white max-sm:shadow-lg`}
             onClick={() => window.print()}
           >
             print

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,7 +67,10 @@ function App() {
 
   return (
     <ThemeContext.Provider value={activeTheme}>
-      <div className="flex items-center gap-4 fixed sm:top-0 right-0 max-sm:bottom-0 print:invisible p-4">
+      <div
+        className={`flex items-center gap-4 fixed m-4 p-2 rounded 
+          print:invisible sm:shadow-lg sm:bg-background sm:top-0 right-0 max-sm:bottom-0`}
+      >
         <div className="flex items-baseline gap-2 relative">
           <label
             className={`max-sm:text-sm max-sm:absolute py-1 px-2 max-sm:left-2 rounded

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,7 +70,7 @@ function App() {
       <div className="flex items-center gap-2 fixed sm:top-0 right-0 max-sm:bottom-0 print:invisible p-4">
         <div className="flex items-baseline gap-2 relative">
           <label
-            className={`max-sm:text-sm max-sm:absolute py-1 px-1 max-sm:left-1 rounded
+            className={`max-sm:text-sm max-sm:absolute py-1 px-2 max-sm:left-2 rounded
               max-sm:top-[-0.75rem] bg-background`}
             id={themePickerLabel}
           >

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,27 +1,17 @@
-import {
-  useCallback,
-  useDeferredValue,
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { AboutMe } from "./AboutMe";
 import "./App.css";
 import { Education } from "./Education";
 import { Experience } from "./Experience";
 import { Links } from "./Links";
-import { Select } from "./Select";
-import { SelectMobile } from "./SelectMobile";
+import { PageControls } from "./PageControls";
 import { ThemeContext } from "./ThemeContext";
 import { useLocalStorage } from "./useLocalStorage";
 import { useSystemPreferredTheme } from "./useSystemPreferredTheme";
-import { useWindowWidth } from "./useWindowWidth";
 
 function App() {
   const htmlRef = useRef(document.documentElement);
-  const themePickerLabel = useId();
+
   const [activeTheme, setActiveTheme] = useState<"dark" | "light">("dark");
 
   // use local storage persisting state for app-level theme preference.
@@ -31,13 +21,7 @@ function App() {
     "auto"
   );
 
-  const windowWidth = useDeferredValue(useWindowWidth());
   const systemPreferredTheme = useSystemPreferredTheme();
-
-  const isAndroid = useMemo(
-    () => navigator.userAgent.toLowerCase().includes("android"),
-    []
-  );
 
   // set the site theme using a class on the main html element
   const setTheme = useCallback((dark: boolean) => {
@@ -67,46 +51,10 @@ function App() {
 
   return (
     <ThemeContext.Provider value={activeTheme}>
-      <div
-        className={`flex items-center gap-4 fixed m-4 p-2 rounded 
-          print:invisible sm:shadow-lg sm:bg-background sm:top-0 right-0 max-sm:bottom-0`}
-      >
-        <div className="flex items-baseline gap-2 relative">
-          <label
-            className={`max-sm:text-sm max-sm:absolute py-1 px-2 max-sm:left-2 rounded
-              max-sm:top-[-0.75rem] bg-background`}
-            id={themePickerLabel}
-          >
-            Theme
-          </label>
-          {windowWidth < 640 ? (
-            <SelectMobile
-              className="shadow-lg"
-              aria-labelledby={themePickerLabel}
-              options={["auto", "dark", "light"]}
-              selectedOption={themePreference ?? "auto"}
-              setSelectedOption={setThemePreference}
-            />
-          ) : (
-            <Select
-              position={"bottom"}
-              aria-labelledby={themePickerLabel}
-              options={["auto", "dark", "light"]}
-              selectedOption={themePreference ?? "auto"}
-              setSelectedOption={setThemePreference}
-            />
-          )}
-        </div>
-        {!isAndroid && (
-          <button
-            className={`material-symbols-outlined text-4xl bg-background rounded-full max-sm:p-2 
-              border border-neutral-400 dark:border-white max-sm:shadow-lg`}
-            onClick={() => window.print()}
-          >
-            print
-          </button>
-        )}
-      </div>
+      <PageControls
+        themePreference={themePreference}
+        setThemePreference={setThemePreference}
+      />
       <div className="space-y-4 max-sm:mb-16">
         <div className="flex justify-center">
           <main className="max-w-4xl px-4 flex-grow space-y-4 mb-8">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,7 +87,8 @@ function App() {
         </div>
         {!isAndroid && (
           <button
-            className="material-symbols-outlined text-4xl bg-background rounded-full max-sm:p-2"
+            className={`material-symbols-outlined text-4xl bg-background rounded-full max-sm:p-2 
+              border border-neutral-400 dark:border-white`}
             onClick={() => window.print()}
           >
             print

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { Education } from "./Education";
 import { Experience } from "./Experience";
 import { Links } from "./Links";
 import { Select } from "./Select";
+import { SelectMobile } from "./SelectMobile";
 import { ThemeContext } from "./ThemeContext";
 import { useLocalStorage } from "./useLocalStorage";
 import { useSystemPreferredTheme } from "./useSystemPreferredTheme";
@@ -75,15 +76,22 @@ function App() {
           >
             Theme
           </label>
-
-          <Select
-            position={windowWidth < 640 ? "top" : "bottom"}
-            aria-labelledby={themePickerLabel}
-            className="sm:w-20"
-            options={["auto", "dark", "light"]}
-            selectedOption={themePreference ?? "auto"}
-            setSelectedOption={setThemePreference}
-          />
+          {windowWidth < 640 ? (
+            <SelectMobile
+              aria-labelledby={themePickerLabel}
+              options={["auto", "dark", "light"]}
+              selectedOption={themePreference ?? "auto"}
+              setSelectedOption={setThemePreference}
+            />
+          ) : (
+            <Select
+              position={"bottom"}
+              aria-labelledby={themePickerLabel}
+              options={["auto", "dark", "light"]}
+              selectedOption={themePreference ?? "auto"}
+              setSelectedOption={setThemePreference}
+            />
+          )}
         </div>
         {!isAndroid && (
           <button

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,7 +70,7 @@ function App() {
       <div className="flex items-center gap-2 fixed sm:top-0 right-0 max-sm:bottom-0 print:invisible p-4">
         <div className="flex items-baseline gap-2 relative">
           <label
-            className={`max-sm:text-xs max-sm:absolute py-1 px-1 max-sm:left-1 rounded
+            className={`max-sm:text-sm max-sm:absolute py-1 px-1 max-sm:left-1 rounded
               max-sm:top-[-0.75rem] bg-background`}
             id={themePickerLabel}
           >

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -1,0 +1,50 @@
+import {
+  ReactNode,
+  useEffect,
+  useRef,
+  HTMLAttributes,
+  forwardRef,
+  useImperativeHandle,
+} from "react";
+
+// HTMLElement is used here to prevent users from using "open" by accident
+type DialogProps = HTMLAttributes<HTMLElement> & {
+  /**
+   * Show the dialog as a modal
+   */
+  show: boolean;
+  /**
+   * Any children to house inside the dialog
+   */
+  children?: ReactNode;
+};
+
+/**
+ * An accessible modal component based on the HTML dialog element.
+ * @param props All the standard HTMLElement props plus `show` to show the dialog
+ */
+export const Dialog = forwardRef<HTMLDialogElement, DialogProps>(
+  (props, ref) => {
+    const { show, children, ...rest } = props;
+
+    const innerRef = useRef<HTMLDialogElement>(null);
+
+    useImperativeHandle(ref, () => innerRef.current as HTMLDialogElement);
+
+    useEffect(() => {
+      if (show) {
+        innerRef.current?.showModal();
+      } else {
+        innerRef.current?.close();
+      }
+    }, [show]);
+
+    return (
+      <dialog {...rest} ref={innerRef}>
+        {children}
+      </dialog>
+    );
+  }
+);
+
+Dialog.displayName = "Dialog";

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -32,9 +32,9 @@ export const Dialog = forwardRef<HTMLDialogElement, DialogProps>(
     useImperativeHandle(ref, () => innerRef.current as HTMLDialogElement);
 
     useEffect(() => {
-      if (show) {
+      if (show && !innerRef.current?.open) {
         innerRef.current?.showModal();
-      } else {
+      } else if (!show && innerRef.current?.open) {
         innerRef.current?.close();
       }
     }, [show]);

--- a/src/PageControls.tsx
+++ b/src/PageControls.tsx
@@ -1,0 +1,61 @@
+import { FunctionComponent, useDeferredValue, useId, useMemo } from "react";
+import { Select } from "./Select";
+import { SelectMobile } from "./SelectMobile";
+import { useWindowWidth } from "./useWindowWidth";
+
+export const PageControls: FunctionComponent<{
+  themePreference: string | null;
+  setThemePreference: (preference: string) => void;
+}> = ({ themePreference, setThemePreference }) => {
+  const themePickerLabel = useId();
+
+  const isAndroid = useMemo(
+    () => navigator.userAgent.toLowerCase().includes("android"),
+    []
+  );
+
+  const windowWidth = useDeferredValue(useWindowWidth());
+
+  return (
+    <div
+      className={`flex items-center gap-4 fixed m-4 p-2 rounded 
+          print:invisible sm:shadow-lg sm:bg-background sm:top-0 right-0 max-sm:bottom-0`}
+    >
+      <div className="flex items-baseline gap-2 relative">
+        <label
+          className={`max-sm:text-sm max-sm:absolute py-1 px-2 max-sm:left-2 rounded
+              max-sm:top-[-0.75rem] bg-background`}
+          id={themePickerLabel}
+        >
+          Theme
+        </label>
+        {windowWidth < 640 ? (
+          <SelectMobile
+            className="shadow-lg"
+            aria-labelledby={themePickerLabel}
+            options={["auto", "dark", "light"]}
+            selectedOption={themePreference ?? "auto"}
+            setSelectedOption={setThemePreference}
+          />
+        ) : (
+          <Select
+            position={"bottom"}
+            aria-labelledby={themePickerLabel}
+            options={["auto", "dark", "light"]}
+            selectedOption={themePreference ?? "auto"}
+            setSelectedOption={setThemePreference}
+          />
+        )}
+      </div>
+      {!isAndroid && (
+        <button
+          className={`material-symbols-outlined text-4xl bg-background rounded-full max-sm:p-2 
+              border border-neutral-400 dark:border-white max-sm:shadow-lg`}
+          onClick={() => window.print()}
+        >
+          print
+        </button>
+      )}
+    </div>
+  );
+};

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useId, useState } from "react";
+import { FunctionComponent, RefObject, useId, useState } from "react";
 import { useOutsideClickHandler } from "./useOutsideClickHandler";
 import { useSelect } from "./useSelect";
 
@@ -59,7 +59,10 @@ export const Select: FunctionComponent<SelectProps> = (props) => {
         {props.selectedOption ?? "Select an option"}
         <span className="material-symbols-outlined">arrow_drop_down</span>
       </button>
-      <div ref={dropdownRef} className={`relative ${!open && "invisible"}`}>
+      <div
+        ref={dropdownRef as RefObject<HTMLDivElement>}
+        className={`relative ${!open && "invisible"}`}
+      >
         <div
           id={listBoxId}
           aria-label={props["aria-label"]}

--- a/src/SelectMobile.tsx
+++ b/src/SelectMobile.tsx
@@ -133,6 +133,8 @@ export const SelectMobile: FunctionComponent<SelectProps> = (props) => {
         <span className="material-symbols-outlined">arrow_drop_down</span>
       </button>
       <Dialog
+        aria-label={props["aria-label"]}
+        aria-labelledby={props["aria-labelledby"]}
         show={open}
         className={`p-0 w-full fixed bottom-4 top-auto bg-background text-text-color text-base
           border border-neutral-400 dark:border-white rounded`}

--- a/src/SelectMobile.tsx
+++ b/src/SelectMobile.tsx
@@ -129,8 +129,8 @@ export const SelectMobile: FunctionComponent<SelectProps> = (props) => {
         aria-expanded={open}
         role="combobox"
         ref={buttonRef}
-        className={`p-2 border items-center bg-background border-neutral-400 dark:border-white 
-            rounded text-left flex justify-between gap-2`}
+        className={`p-4 border items-center bg-background border-neutral-400 dark:border-white 
+            rounded text-left flex justify-between gap-4 text-base`}
         onClick={onClickExpand}
         value={props.selectedOption}
       >
@@ -139,7 +139,7 @@ export const SelectMobile: FunctionComponent<SelectProps> = (props) => {
       </button>
       <Dialog
         show={open}
-        className={`p-0 w-full fixed bottom-4 top-auto bg-background text-text-color 
+        className={`p-0 w-full fixed bottom-4 top-auto bg-background text-text-color text-base
           border border-neutral-400 dark:border-white rounded`}
         ref={dropdownRef}
       >

--- a/src/SelectMobile.tsx
+++ b/src/SelectMobile.tsx
@@ -12,7 +12,6 @@ import { useOutsideClickHandler } from "./useOutsideClickHandler";
 interface SelectProps {
   "aria-label"?: string;
   "aria-labelledby"?: string;
-  position?: "top" | "bottom";
   className?: string;
   options: string[];
   selectedOption: string | undefined;
@@ -117,11 +116,7 @@ export const SelectMobile: FunctionComponent<SelectProps> = (props) => {
   };
 
   return (
-    <div
-      className={`flex ${
-        props.position === "top" ? "flex-col-reverse" : "flex-col"
-      } ${props.className}`}
-    >
+    <div className={`flex ${props.className}`}>
       <button
         aria-label={props["aria-label"]}
         aria-labelledby={props["aria-labelledby"]}

--- a/src/SelectMobile.tsx
+++ b/src/SelectMobile.tsx
@@ -18,7 +18,7 @@ interface SelectProps {
   setSelectedOption: (option: string) => void;
 }
 
-export const Select: FunctionComponent<SelectProps> = (props) => {
+export const SelectMobile: FunctionComponent<SelectProps> = (props) => {
   const [open, setOpen] = useState<boolean>(false);
 
   const listBoxId = useId();
@@ -129,7 +129,7 @@ export const Select: FunctionComponent<SelectProps> = (props) => {
         role="combobox"
         ref={buttonRef}
         className={`p-2 border items-center bg-background border-neutral-400 dark:border-white 
-          rounded text-left flex justify-between gap-2`}
+            rounded text-left flex justify-between gap-2`}
         onClick={onClickExpand}
         value={props.selectedOption}
       >
@@ -144,7 +144,7 @@ export const Select: FunctionComponent<SelectProps> = (props) => {
           className={`flex flex-col absolute border ${
             props.position === "top" && "translate-y-[-100%]"
           } bg-background border-neutral-400 
-            dark:border-white rounded w-full`}
+              dark:border-white rounded w-full`}
           role="listbox"
           onBlur={onBlur}
           onKeyDown={onMenuKeyDown}

--- a/src/SelectMobile.tsx
+++ b/src/SelectMobile.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { Dialog } from "./Dialog";
 import { useOutsideClickHandler } from "./useOutsideClickHandler";
 
 interface SelectProps {
@@ -23,7 +24,7 @@ export const SelectMobile: FunctionComponent<SelectProps> = (props) => {
 
   const listBoxId = useId();
 
-  const dropdownRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLDialogElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   // close menu and restore focus to the open button
@@ -136,15 +137,17 @@ export const SelectMobile: FunctionComponent<SelectProps> = (props) => {
         {props.selectedOption ?? "Select an option"}
         <span className="material-symbols-outlined">arrow_drop_down</span>
       </button>
-      <div ref={dropdownRef} className={`relative ${!open && "invisible"}`}>
+      <Dialog
+        show={open}
+        className={`p-0 w-full fixed bottom-4 top-auto bg-background text-text-color 
+          border border-neutral-400 dark:border-white rounded`}
+        ref={dropdownRef}
+      >
         <div
           id={listBoxId}
           aria-label={props["aria-label"]}
           aria-labelledby={props["aria-labelledby"]}
-          className={`flex flex-col absolute border ${
-            props.position === "top" && "translate-y-[-100%]"
-          } bg-background border-neutral-400 
-              dark:border-white rounded w-full`}
+          className="flex flex-col"
           role="listbox"
           onBlur={onBlur}
           onKeyDown={onMenuKeyDown}
@@ -160,7 +163,7 @@ export const SelectMobile: FunctionComponent<SelectProps> = (props) => {
                 tabIndex={-1}
                 ref={refs[index]}
                 className={
-                  "p-2 flex items-baseline justify-between w-full text-left whitespace-nowrap"
+                  "p-4 flex items-baseline justify-between w-full text-left whitespace-nowrap"
                 }
                 onClick={() => onClickItem(option)}
               >
@@ -177,7 +180,7 @@ export const SelectMobile: FunctionComponent<SelectProps> = (props) => {
             );
           })}
         </div>
-      </div>
+      </Dialog>
     </div>
   );
 };

--- a/src/SelectMobile.tsx
+++ b/src/SelectMobile.tsx
@@ -1,13 +1,7 @@
-import {
-  createRef,
-  FunctionComponent,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { FunctionComponent, RefObject, useId, useState } from "react";
 import { Dialog } from "./Dialog";
 import { useOutsideClickHandler } from "./useOutsideClickHandler";
+import { useSelect } from "./useSelect";
 
 interface SelectProps {
   "aria-label"?: string;
@@ -19,101 +13,30 @@ interface SelectProps {
 }
 
 export const SelectMobile: FunctionComponent<SelectProps> = (props) => {
+  const { selectedOption, setSelectedOption } = props;
+
   const [open, setOpen] = useState<boolean>(false);
 
   const listBoxId = useId();
 
-  const dropdownRef = useRef<HTMLDialogElement>(null);
-  const buttonRef = useRef<HTMLButtonElement>(null);
-
-  // close menu and restore focus to the open button
-  const onClose = () => {
-    setOpen(false);
-
-    buttonRef.current?.focus();
-  };
+  const {
+    buttonRef,
+    dropdownRef,
+    optionRefs,
+    onBlur,
+    onClickExpand,
+    onClickItem,
+    onMenuKeyDown,
+  } = useSelect({
+    open,
+    options: props.options,
+    setOpen,
+    selectedOption,
+    setSelectedOption,
+  });
 
   // close the menu when someone clicks outside of it
   useOutsideClickHandler(dropdownRef, () => setOpen(false));
-
-  // create refs for each item
-  const refs = useMemo(
-    () =>
-      Array.from({ length: props.options.length }).map(() =>
-        createRef<HTMLButtonElement>()
-      ),
-    [props.options]
-  );
-
-  // focus an option by its index
-  const focusOption = (index: number) => {
-    refs[index].current?.focus();
-  };
-
-  // close the dropdown on focus loss
-  const onBlur = (e: React.FocusEvent) => {
-    // onBlur can trigger even if the focus has switched to another child
-    if (dropdownRef.current?.contains(e.relatedTarget)) {
-      return;
-    }
-
-    setOpen(false);
-  };
-
-  // open the menu when the dropdown button is click
-  const onClickExpand = () => {
-    if (!open) {
-      setOpen(true);
-
-      const selectedIndex = props.options.findIndex(
-        (option) => option === props.selectedOption
-      );
-
-      setTimeout(
-        () => focusOption(selectedIndex !== -1 ? selectedIndex : 0),
-        0
-      );
-    }
-  };
-
-  // select an option on clicking its button
-  const onClickItem = (option: string) => {
-    props.setSelectedOption(option);
-    onClose();
-  };
-
-  // handle dropdown menu-wide keypresses
-  const onMenuKeyDown = (e: React.KeyboardEvent) => {
-    switch (e.key) {
-      case "Escape":
-        e.preventDefault();
-
-        onClose();
-        break;
-      case "ArrowDown":
-      case "ArrowRight":
-        {
-          e.preventDefault();
-
-          const focusedIndex = refs.findIndex(
-            (bRef) => bRef.current === document.activeElement
-          );
-          focusOption((focusedIndex + 1) % props.options.length);
-        }
-        break;
-      case "ArrowUp":
-      case "ArrowLeft":
-        {
-          e.preventDefault();
-
-          const focusedIndex = refs.findIndex(
-            (bRef) => bRef.current === document.activeElement
-          );
-          focusOption((focusedIndex - 1) % props.options.length);
-        }
-        break;
-    }
-  };
 
   return (
     <div className={`flex ${props.className}`}>
@@ -138,7 +61,7 @@ export const SelectMobile: FunctionComponent<SelectProps> = (props) => {
         show={open}
         className={`p-0 w-full fixed bottom-4 top-auto bg-background text-text-color text-base
           border border-neutral-400 dark:border-white rounded`}
-        ref={dropdownRef}
+        ref={dropdownRef as RefObject<HTMLDialogElement>}
       >
         <div
           id={listBoxId}
@@ -158,7 +81,7 @@ export const SelectMobile: FunctionComponent<SelectProps> = (props) => {
                 aria-selected={selected}
                 role="option"
                 tabIndex={-1}
-                ref={refs[index]}
+                ref={optionRefs[index]}
                 className={
                   "p-4 flex items-baseline justify-between w-full text-left whitespace-nowrap"
                 }

--- a/src/useSelect.tsx
+++ b/src/useSelect.tsx
@@ -7,7 +7,7 @@ export const useSelect = (props: {
   selectedOption: string | undefined;
   setSelectedOption: (option: string) => void;
 }) => {
-  const dropdownRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   // create refs for each item

--- a/src/useSelect.tsx
+++ b/src/useSelect.tsx
@@ -1,0 +1,108 @@
+import { createRef, useMemo, useRef } from "react";
+
+export const useSelect = (props: {
+  options: string[];
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  selectedOption: string | undefined;
+  setSelectedOption: (option: string) => void;
+}) => {
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  // create refs for each item
+  const optionRefs = useMemo(
+    () =>
+      Array.from({ length: props.options.length }).map(() =>
+        createRef<HTMLButtonElement>()
+      ),
+    [props.options]
+  );
+
+  // close the dropdown on focus loss
+  const onBlur = (e: React.FocusEvent) => {
+    // onBlur can trigger even if the focus has switched to another child
+    if (dropdownRef.current?.contains(e.relatedTarget)) {
+      return;
+    }
+
+    props.setOpen(false);
+  };
+
+  // close menu and restore focus to the open button
+  const onClose = () => {
+    props.setOpen(false);
+
+    buttonRef.current?.focus();
+  };
+
+  // open the menu when the dropdown button is click
+  const onClickExpand = () => {
+    if (!props.open) {
+      props.setOpen(true);
+
+      const selectedIndex = props.options.findIndex(
+        (option) => option === props.selectedOption
+      );
+
+      setTimeout(
+        () => focusOption(selectedIndex !== -1 ? selectedIndex : 0),
+        0
+      );
+    }
+  };
+
+  // select an option on clicking its button
+  const onClickItem = (option: string) => {
+    props.setSelectedOption(option);
+    onClose();
+  };
+
+  // handle dropdown menu-wide keypresses
+  const onMenuKeyDown = (e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case "Escape":
+        e.preventDefault();
+
+        onClose();
+        break;
+      case "ArrowDown":
+      case "ArrowRight":
+        {
+          e.preventDefault();
+
+          const focusedIndex = optionRefs.findIndex(
+            (bRef) => bRef.current === document.activeElement
+          );
+          focusOption((focusedIndex + 1) % props.options.length);
+        }
+        break;
+      case "ArrowUp":
+      case "ArrowLeft":
+        {
+          e.preventDefault();
+
+          const focusedIndex = optionRefs.findIndex(
+            (bRef) => bRef.current === document.activeElement
+          );
+          focusOption((focusedIndex - 1) % props.options.length);
+        }
+        break;
+    }
+  };
+
+  // focus an option by its index
+  const focusOption = (index: number) => {
+    optionRefs[index].current?.focus();
+  };
+
+  return {
+    buttonRef,
+    dropdownRef,
+    optionRefs,
+    onBlur,
+    onClickExpand,
+    onClickItem,
+    onMenuKeyDown,
+  };
+};


### PR DESCRIPTION
The click targets for page controls on mobile are currently pretty small. This PR aims to improve that.

## Before
### Desktop
![image](https://user-images.githubusercontent.com/25556936/220772157-be2afe02-3d59-4f16-941a-fc377df02fa3.png)

### Mobile
![image](https://user-images.githubusercontent.com/25556936/220772288-3cf0d23f-36eb-493d-b484-41d0f42c9f25.png)

## After
### Desktop
![image](https://user-images.githubusercontent.com/25556936/220772099-e5b203e5-588c-43ac-b32e-006cbc47581e.png)

### Mobile
![image](https://user-images.githubusercontent.com/25556936/220772012-637f2ac3-1894-452d-8d11-2996d6f1ea1a.png)

